### PR TITLE
fix: Correct default `http_version` from float to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ BUG FIXES:
 - Correct cleanup error when `nginx_config_cleanup_paths` is not defined.
 - Disable check_mode for validation task `jinja2_version`.
 - The default PID path has changed as of NGINX 1.27.5 and 1.28.0.
+- Properly wrap `http_version` number in quotes in both the template defaults and Molecule tests.
 
 TESTS:
 

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -436,7 +436,7 @@ nginx_config_http_template:
         headers_hash_bucket_size: 64
         headers_hash_max_size: 512
         hide_header: Date  # String or a list of strings
-        http_version: 1.1  # Can be set to '1.0' or '1.1'
+        http_version: '1.1'  # Can be set to '1.0' or '1.1'
         ignore_client_abort: false  # Boolean
         ignore_headers: X-Accel-Redirect  # String or a list of strings -- Can be set to 'X-Accel-Redirect', 'X-Accel-Expires', 'X-Accel-Limit-Rate', 'X-Accel-Buffering', 'X-Accel-Charset', 'Expires', 'Cache-Control', 'Set-Cookie' or 'Vary'
         intercept_errors: false  # Boolean

--- a/molecule/complete/converge.yml
+++ b/molecule/complete/converge.yml
@@ -349,7 +349,7 @@
                 hide_header:
                   - Date
                   - X-Accel-Redirect
-                http_version: 1.1
+                http_version: '1.1'
                 ignore_client_abort: false
                 ignore_headers:
                   - X-Accel-Redirect
@@ -460,7 +460,7 @@
                 comp_level: 1
                 disable:
                   - '"msie6"'
-                http_version: 1.1
+                http_version: '1.1'
                 min_length: 20
                 proxied:
                   - expired

--- a/molecule/complete_plus/converge.yml
+++ b/molecule/complete_plus/converge.yml
@@ -208,7 +208,7 @@
                 comp_level: 1
                 disable:
                   - '"msie6"'
-                http_version: 1.1
+                http_version: '1.1'
                 min_length: 20
                 proxied:
                   - expired
@@ -477,7 +477,7 @@
                         hide_header:
                           - Date
                           - X-Accel-Redirect
-                        http_version: 1.1
+                        http_version: '1.1'
                         ignore_client_abort: false
                         ignore_headers:
                           - X-Accel-Redirect


### PR DESCRIPTION
### Proposed changes

This is a simple fix that corrects the value of the default http_version to a string, which is what is required/expected by Nginx itself.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document.
- [x] I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CHANGELOG.md)).

I'll admit to being lazy and not running any Molecule tests here, though one should probably be added to catch this. I have very little experience with Molecule, but I'm willing to add it if someone can give me a few hints on where to look and what to do.