### PR TITLE
chore: Replace nginxinc GH org mentions with nginx

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,8 +14,8 @@ body:
 
         **Note:** If you are seeking community support or have a question, please consider starting a new thread via [GitHub discussions][discussions] or the [NGINX Community forum][forum].
 
-        [issue search]: https://github.com/nginxinc/ansible-role-nginx-config/issues
-        [discussions]: https://github.com/nginxinc/ansible-role-nginx-config/discussions
+        [issue search]: https://github.com/nginx/ansible-role-nginx-config/issues
+        [discussions]: https://github.com/nginx/ansible-role-nginx-config/discussions
         [forum]: https://community.nginx.org
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -12,8 +12,8 @@ body:
 
         **Note:** If you are seeking community support or have a question, please consider starting a new thread via [GitHub discussions][discussions] or the [NGINX Community forum][forum].
 
-        [issue search]: https://github.com/nginxinc/ansible-role-nginx-config/issues
-        [discussions]: https://github.com/nginxinc/ansible-role-nginx-config/discussions
+        [issue search]: https://github.com/nginx/ansible-role-nginx-config/issues
+        [discussions]: https://github.com/nginx/ansible-role-nginx-config/discussions
         [forum]: https://community.nginx.org
 
   - type: textarea

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -127,7 +127,7 @@ template: |
 
   ## Resources
 
-  - Functional configuration examples (check `converge.yml` under each `molecule` scenario) -- [github.com/nginxinc/ansible-role-nginx-config/tree/$RESOLVED_VERSION/molecule](https://github.com/nginxinc/ansible-role-nginx-config/tree/$RESOLVED_VERSION/molecule).
+  - Functional configuration examples (check `converge.yml` under each `molecule` scenario) -- [github.com/nginx/ansible-role-nginx-config/tree/$RESOLVED_VERSION/molecule](https://github.com/nginx/ansible-role-nginx-config/tree/$RESOLVED_VERSION/molecule).
   - Ansible Galaxy repository -- [galaxy.ansible.com/nginxinc/nginx_config](https://galaxy.ansible.com/nginxinc/nginx_config).
   - NGINX Ansible role & collection introductory blog -- [nginx.com/blog/announcing-nginx-core-collection-ansible](https://www.f5.com/blog/announcing-nginx-core-collection-ansible).
   - NGINX: Better with Ansible demo -- [github.com/alessfg/nginx-ansible-demo](https://github.com/alessfg/nginx-ansible-demo).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,7 +165,7 @@ BREAKING CHANGES:
         proxy: {}
     ```
 
-  - Check [`defaults/main/template.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/template.yml) and [`molecule/default/converge.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/molecule/default/converge.yml) for examples!
+  - Check [`defaults/main/template.yml`](https://github.com/nginx/ansible-role-nginx-config/blob/main/defaults/main/template.yml) and [`molecule/default/converge.yml`](https://github.com/nginx/ansible-role-nginx-config/blob/main/molecule/default/converge.yml) for examples!
   - These changes follow in the footsteps of the `http` Jinja2 refactor introduced in the `0.4.0` release. If you want more information on how to port your `stream` configurations, the release notes/changelog for `0.4.0` are a good place to start.
 - Replace `conf_file_name` and `conf_file_location` with `deployment_location` inside `nginx_config_stream_template`.
 - Replace `html_file_name` and `html_file_location` with `deployment_location` inside `nginx_config_html_demo_template`.
@@ -184,7 +184,7 @@ BUG FIXES:
 - Fix a bug when using a single `custom_directives` entry and the http template.
 - Fix check mode issue when running with SELinux enabled. Role no longer reports a change in check mode when setting the host to permissive mode.
 - Fix typo in the REST API template.
-- Fix incorrect REST API and status log variable names in [`defaults/main/template.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/template.yml).
+- Fix incorrect REST API and status log variable names in [`defaults/main/template.yml`](https://github.com/nginx/ansible-role-nginx-config/blob/main/defaults/main/template.yml).
 - Fix bugged conditional check in the `http/ssl.j2` Jinja2 template.
 
 ## 0.4.2 (October 28, 2021)
@@ -244,7 +244,7 @@ Template engine updates:
             proxy: {}
     ```
 
-  - Check [`defaults/main/template.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/template.yml) and [`molecule/default/converge.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/molecule/default/converge.yml) for examples!
+  - Check [`defaults/main/template.yml`](https://github.com/nginx/ansible-role-nginx-config/blob/main/defaults/main/template.yml) and [`molecule/default/converge.yml`](https://github.com/nginx/ansible-role-nginx-config/blob/main/molecule/default/converge.yml) for examples!
 - Refactor the base config templates to simplify the creation of templates as well as development and maintenance moving forward:
   - Modify `servers`, `servers.listen`, `server.locations`, `upstream` and `upstream.servers` from nested dictionaries in the `http` and `stream` configuration templates to lists.
   - Remove/merge the `web_server` and `reverse_proxy` nested dictionary keys from the HTTP templates. These often lead to confusing and unnecessary code duplication and hard to maintain code. To update your templates, remove both keys and adjust your spacing accordingly.
@@ -295,7 +295,7 @@ Template engine updates:
 - Refactor the `keyval` directives into its own template config that now includes all the `keyval` HTTP module directives:
   - Both `keyval` directives now live within the `keyval` dictionary.
   - The `keyval` dictionary now lives in the HTTP template config instead of the Main template config.
-- Refactor `server.health_check_plus` into its own dictionary that now includes all the `health_check` module directives (check [`defaults/main/template.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/template.yml) for examples).
+- Refactor `server.health_check_plus` into its own dictionary that now includes all the `health_check` module directives (check [`defaults/main/template.yml`](https://github.com/nginx/ansible-role-nginx-config/blob/main/defaults/main/template.yml) for examples).
 - Refactor the `limit_req` directive into its own dictionary:
   - The `limit_req` directives now live within the `limit_req` dictionary.
   - The `limit_req` dictionary now lives in the HTTP template config instead of the Main template config.
@@ -533,4 +533,4 @@ An empty `nginx_config_cleanup_files` will no longer cause `nginx_config_cleanup
 
 ## 0.1.0 (August 19, 2020)
 
-Initial release of the NGINX Config role. Contains all NGINX Config related features previously available on the [NGINX Ansible role](https://github.com/nginxinc/ansible-role-nginx).
+Initial release of the NGINX Config role. Contains all NGINX Config related features previously available on the [NGINX Ansible role](https://github.com/nginx/ansible-role-nginx).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Ansible Galaxy](https://img.shields.io/badge/galaxy-nginxinc.nginx__config-5bbdbf.svg)](https://galaxy.ansible.com/nginxinc/nginx_config)
-[![Molecule CI/CD](https://github.com/nginxinc/ansible-role-nginx-config/actions/workflows/molecule.yml/badge.svg)](https://github.com/nginxinc/ansible-role-nginx-config/actions/workflows/molecule.yml)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/nginxinc/ansible-role-nginx-config/badge)](https://securityscorecards.dev/viewer/?uri=github.com/nginxinc/ansible-role-nginx-config)
+[![Molecule CI/CD](https://github.com/nginx/ansible-role-nginx-config/actions/workflows/molecule.yml/badge.svg)](https://github.com/nginx/ansible-role-nginx-config/actions/workflows/molecule.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/nginx/ansible-role-nginx-config/badge)](https://securityscorecards.dev/viewer/?uri=github.com/nginx/ansible-role-nginx-config)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![Community Support](https://badgen.net/badge/support/community/cyan?icon=awesome)](/SUPPORT.md)
 [![Community Forum](https://img.shields.io/badge/community-forum-009639?logo=discourse&link=https%3A%2F%2Fcommunity.nginx.org)](https://community.nginx.org)
@@ -25,8 +25,8 @@ If you want to use this role, you will need to use a supported version of Ansibl
 For ease of use, you can install and/or upgrade Ansible core, Jinja2, and the aforementioned Ansible collections by running the following four commands on your Ansible host:
 
 ```bash
-pip install --upgrade -r https://raw.githubusercontent.com/nginxinc/ansible-role-nginx-config/main/.github/workflows/requirements/requirements_ansible.txt
-curl -O https://raw.githubusercontent.com/nginxinc/ansible-role-nginx-config/main/.github/workflows/requirements/requirements_collections.yml
+pip install --upgrade -r https://raw.githubusercontent.com/nginx/ansible-role-nginx-config/main/.github/workflows/requirements/requirements_ansible.txt
+curl -O https://raw.githubusercontent.com/nginx/ansible-role-nginx-config/main/.github/workflows/requirements/requirements_collections.yml
 ansible-galaxy install --force -r requirements_collections.yml
 rm -f requirements_collections.yml
 ```
@@ -79,7 +79,7 @@ If you want to contribute to this role, you will also need to install Ansible Li
 - For ease of use, you can install and/or upgrade Ansible Lint by running the following command on your Ansible host:
 
   ```bash
-  pip install -r https://raw.githubusercontent.com/nginxinc/ansible-role-nginx-config/main/.github/workflows/requirements/requirements_ansible_lint.txt
+  pip install -r https://raw.githubusercontent.com/nginx/ansible-role-nginx-config/main/.github/workflows/requirements/requirements_ansible_lint.txt
   ```
 
 #### Molecule (Optional)
@@ -99,7 +99,7 @@ If you want to contribute to this role, you will also need to install Ansible Li
 - For ease of use, you can install and/or upgrade Molecule, the Molecule plugins package, and the Docker Python SDK by running the following command on your Ansible host:
 
   ```bash
-  pip install --upgrade -r https://raw.githubusercontent.com/nginxinc/ansible-role-nginx-config/main/.github/workflows/requirements/requirements_molecule.txt
+  pip install --upgrade -r https://raw.githubusercontent.com/nginx/ansible-role-nginx-config/main/.github/workflows/requirements/requirements_molecule.txt
   ```
 
 ## Role Installation
@@ -133,7 +133,7 @@ To use the role, include the following task in your playbook:
 To pull the latest edge commit of the role from GitHub, use:
 
 ```bash
-git clone https://github.com/nginxinc/ansible-role-nginx-config.git
+git clone https://github.com/nginx/ansible-role-nginx-config.git
 ```
 
 To use the role, include the following task in your playbook:
@@ -185,7 +185,7 @@ Working functional playbook examples can be found in the **[`molecule/`](/molecu
 
 You can find the Ansible NGINX Core collection of roles to install and configure NGINX Open Source, NGINX Plus, and NGINX App Protect [here](https://github.com/nginxinc/ansible-collection-nginx).
 
-You can find the Ansible NGINX role to install NGINX OSS and NGINX Plus [here](https://github.com/nginxinc/ansible-role-nginx).
+You can find the Ansible NGINX role to install NGINX OSS and NGINX Plus [here](https://github.com/nginx/ansible-role-nginx).
 
 You can find the Ansible NGINX App Protect role to install and configure NGINX App Protect WAF and NGINX App Protect DoS [here](https://github.com/nginxinc/ansible-role-nginx-app-protect).
 


### PR DESCRIPTION
### Proposed changes

See title. Not every mention has been changed since:
a) The Ansible project board still needs to be migrated
b) The roles are still under the nginxinc org in Ansible Galaxy

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
