### PR TITLE
feat: Ensure NGINX service is enabled on boot when reloading

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -23,6 +23,7 @@
   ansible.builtin.service:
     name: nginx
     state: reloaded
+    enabled: true
   when:
     - nginx_config_start | bool
     - not ansible_check_mode | bool


### PR DESCRIPTION
### Proposed changes

This is kinda required if `nginx_config` is used as standalone role to configure and enable the service after install.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
