### PR TITLE
fix: Default NGINX PID path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ BUG FIXES:
 - Fix incompatibility when using the `listen` directive and setting both the `quic` and `so_keepalive` parameters.
 - Correct cleanup error when `nginx_config_cleanup_paths` is not defined.
 - Disable check_mode for validation task `jinja2_version`.
+- The default PID path has changed as of NGINX 1.27.5 and 1.28.0.
 
 TESTS:
 

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -36,7 +36,7 @@ nginx_config_main_template:
         # - /var/log/nginx/error.log
         # - file: /var/log/nginx/error.log  # Required
         #   level: notice
-      pid: /var/run/nginx.pid
+      pid: /run/nginx.pid
       # daemon: true  # Boolean
       # debug_points: abort  # Can be set to 'abort' or 'stop'
       # env:  # MALLOC_OPTIONS  # String, a list of strings, a dictionary, or a list of dictionaries. The 'variable' variable is only required when setting a 'value'.

--- a/molecule/common/files/nginx.conf
+++ b/molecule/common/files/nginx.conf
@@ -2,7 +2,7 @@ user  nginx;
 worker_processes  4;
 
 error_log  /var/log/nginx/error.log warn;
-pid        /var/run/nginx.pid;
+pid        /run/nginx.pid;
 
 events {
     worker_connections  1024;

--- a/molecule/complete/converge.yml
+++ b/molecule/complete/converge.yml
@@ -53,7 +53,7 @@
                 - file: /var/log/nginx/molecule.log
                 - file: /var/log/nginx/error.log
                   level: notice
-              pid: /var/run/nginx.pid
+              pid: /run/nginx.pid
               daemon: true
               debug_points: abort
               env:

--- a/molecule/complete_plus/converge.yml
+++ b/molecule/complete_plus/converge.yml
@@ -30,7 +30,7 @@
               error_log:
                 - file: /var/log/nginx/error.log
                   level: notice
-              pid: /var/run/nginx.pid
+              pid: /run/nginx.pid
               worker_rlimit_nofile: 2048
             events:
               worker_connections: 1024

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -20,7 +20,7 @@
               error_log:
                 file: /var/log/nginx/error.log
                 level: notice
-              pid: /var/run/nginx.pid
+              pid: /run/nginx.pid
             events:
               worker_connections: 1024
             http:


### PR DESCRIPTION
### Proposed changes

The default PID path has changed from `/var/run/nginx.pid` to `/run/nginx.pid` as of NGINX 1.27.5 and 1.28.0.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
