### PR TITLE
fix: Properly check Ansible collections in check mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ BUG FIXES:
 - Fix the default path for the stream template deployment location.
 - Fix incompatibility when using the `listen` directive and setting both the `quic` and `so_keepalive` parameters.
 - Correct cleanup error when `nginx_config_cleanup_paths` is not defined.
-- Disable check_mode for validation task `jinja2_version`.
+- Disable check_mode for `jinja2_version` and Ansible collections validation tasks.
 - The default PID path has changed as of NGINX 1.27.5 and 1.28.0.
 
 TESTS:

--- a/tasks/validate/validate.yml
+++ b/tasks/validate/validate.yml
@@ -32,6 +32,7 @@
       ansible.builtin.command: ansible-galaxy collection list
       register: collection_list
       changed_when: false
+      check_mode: false
 
     - name: Verify that the 'community.general' Ansible collection is installed on your Ansible host
       ansible.builtin.assert:


### PR DESCRIPTION
### Proposed changes

Disable `check_mode` for Ansible collections validation task.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
