### PR TITLE
fix:  NGINX `set_real_ip_from` directive should be a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ BUG FIXES:
 - Correct cleanup error when `nginx_config_cleanup_paths` is not defined.
 - Disable check_mode for validation task `jinja2_version`.
 - The default PID path has changed as of NGINX 1.27.5 and 1.28.0.
+- NGINX `set_real_ip_from` directive template parameter should be a list.
 
 TESTS:
 

--- a/molecule/complete_plus/converge.yml
+++ b/molecule/complete_plus/converge.yml
@@ -315,7 +315,8 @@
                       - value: '"~jndi:ldap"'
                         new_value: 1
               realip:
-                set_real_ip_from: 0.0.0.0
+                set_real_ip_from:
+                  - 0.0.0.0
                 real_ip_header: X-Real-IP
                 real_ip_recursive: false
               rewrite:

--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -254,8 +254,12 @@ mirror_request_body {{ mirror['request_body'] | ternary('on', 'off') }};
 
 {# NGINX HTTP RealIP -- ngx_http_realip_module #}
 {% macro realip(realip) %}
-{% if realip['set_real_ip_from'] is defined %}
+{% if realip['set_real_ip_from'] is defined and realip['set_real_ip_from'] is not mapping %}
+{% for set_real_ip_from in realip['set_real_ip_from'] if realip['set_real_ip_from'] is not string %}
+set_real_ip_from {{ set_real_ip_from }};
+{% else %}
 set_real_ip_from {{ realip['set_real_ip_from'] }};
+{% endfor %}
 {% endif %}
 {% if realip['real_ip_header'] is defined %}
 real_ip_header {{ realip['real_ip_header'] }};


### PR DESCRIPTION
### Proposed changes

NGINX `set_real_ip_from` directive template parameter should be a list. Fixes #415.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
