### PR TITLE
fix: backup parameter of stream templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ BUG FIXES:
 - The default PID path has changed as of NGINX 1.27.5 and 1.28.0.
 - Properly wrap `http_version` number in quotes in both the template defaults and Molecule tests.
 - NGINX `set_real_ip_from` directive template parameter should be a list.
+- Fix backup parameter for stream templates.
 
 TESTS:
 

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -794,6 +794,7 @@ nginx_config_stream_template_enable: false
 nginx_config_stream_template:
   - template_file: stream/default.conf.j2
     deployment_location: /etc/nginx/conf.d/streams/stream_default.conf
+    backup: true
     config:
       upstreams:  # Configure upstreams
         - name: stream_upstream  # Required

--- a/molecule/complete/converge.yml
+++ b/molecule/complete/converge.yml
@@ -760,6 +760,7 @@
         nginx_config_stream_template:
           - template_file: stream/default.conf.j2
             deployment_location: /etc/nginx/conf.d/streams/stream_default.conf
+            backup: true
             config:
               upstreams:
                 - name: stream_upstream

--- a/molecule/complete_plus/converge.yml
+++ b/molecule/complete_plus/converge.yml
@@ -656,6 +656,7 @@
         nginx_config_stream_template:
           - template_file: stream/default.conf.j2
             deployment_location: /etc/nginx/conf.d/streams/stream_default.conf
+            backup: true
             config:
               upstreams:
                 - name: stream_upstream

--- a/tasks/config/template-config.yml
+++ b/tasks/config/template-config.yml
@@ -121,7 +121,7 @@
   ansible.builtin.template:
     src: "{{ item['template_file'] | default('stream/default.conf.j2') }}"
     dest: "{{ item['deployment_location'] | default('/etc/nginx/conf.d/stream/stream_default.conf') }}"
-    backup: true
+    backup: "{{ item['backup'] | default(true) }}"
     mode: "0644"
   loop: "{{ nginx_config_stream_template }}"
   loop_control:


### PR DESCRIPTION
### Proposed changes

The template backup parameter was made configurable in #205. For stream templates this was reverted in #217. With this patch the backup parameter for stream templates is configurable again. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
